### PR TITLE
Return stdout/stderr on exec.ExitError.

### DIFF
--- a/cmd/httpsdir/main.go
+++ b/cmd/httpsdir/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"os/exec"
 
 	"github.com/icio/mkcert"
 )
@@ -34,7 +37,13 @@ func main() {
 		// mkcert.KeyFile(filepath.Join(dir, "key.pem")),
 	)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+
+		var perr *exec.ExitError
+		if errors.As(err, &perr) {
+			log.Println("mkcert stderr:", string(perr.Stderr))
+		}
+		os.Exit(1)
 	}
 
 	log.Printf("Using certificate: %#v", cert)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/icio/mkcert
 
-go 1.12
+go 1.13

--- a/mkcert.go
+++ b/mkcert.go
@@ -63,8 +63,12 @@ func Exec(opts ...Opt) (Cert, error) {
 	cmd := exec.Command("mkcert", append(args, p.domains...)...)
 	cmd.Dir = p.dir
 	out, err := cmd.CombinedOutput()
+
 	if err != nil {
-		return Cert{}, fmt.Errorf("mkcert: %s", err)
+		if perr, ok := err.(*exec.ExitError); ok {
+			perr.Stderr = out
+		}
+		return Cert{}, fmt.Errorf("mkcert: %w", err)
 	}
 
 	certFile, keyFile := parseFiles(out)

--- a/testdata/bin/stderr/mkcert
+++ b/testdata/bin/stderr/mkcert
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo Derp >&2
+exit 1


### PR DESCRIPTION
testdata/bin/* can be added from the front of your PATH to mock output from mkcert.